### PR TITLE
Added support for clear on linux and osx

### DIFF
--- a/Games/rock_paper_scissors/rock_paper_scissors.py
+++ b/Games/rock_paper_scissors/rock_paper_scissors.py
@@ -1,5 +1,6 @@
 import os
 import random
+import sys
 from time import sleep
 
 choices = ['rock', 'paper', 'scissors']
@@ -10,7 +11,17 @@ round_counter = 0
 
 clear = lambda: os.system('cls')
 
-print('Welcome to Rock Paper Scissors!')
+def clear():
+    if sys.platform in ["linux", "linux2", "darwin"]:
+        # linux or OS X
+        os.system("clear")
+    elif sys.platform == "win32":
+        # Windows
+        os.system("cls")
+
+
+clear()
+print("Welcome to Rock Paper Scissors!")
 
 while True:
     cpu_choice = random.choice(choices)


### PR DESCRIPTION
The terminal is now properly cleared based on the users system platform. Also added a clear statement before the first welcome message for a cleaner begin to the game.

Closes #68. 

### Note

I noticed across the repo the following implementation:

```python
def clear():
    if platform == "linux" or platform == "linux2":
        # linux
        os.system("clear")
    elif platform == "darwin":
        # OS X
        os.system("clear")
    elif platform == "win32":
        # Windows...
        os.system("CLS")
```

I decided to write my implementation a little differently due to my own coding style, but if you'd prefer congruity, I'm happy to change it to be consistent with the other games. 