### PR TITLE
Fix missing references in README overview section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ python "file_name.py"
 - [Ludo King](Games/ludo_king)
 - [Magic8Ball](Games/magic8ball)
 - [Chin Chiro](Games/chin_chiro)
+- [Higher or Lower](Games/Higher_lower)
+- [Gamble](Games/gambler)
+- [Memorise cards](Games/memory_game)
 <!--GAMES_END-->
 <br />
 
@@ -137,6 +140,8 @@ python "file_name.py"
 - [Custom Password Generator](Tools/custom_password_generator)
 - [Binary Converter](Tools/binary_converter)
 - [Expense Tracker](<Tools/Expense Tracker>)
+- [Encoding and decoding images](<Tools/Image encoding and decoding>)
+
 <!--TOOLS_END-->
 
 <br />


### PR DESCRIPTION
To resolve issue  #80 "[Documentation] Missing references in the README overview". 

The following items appear to be missing from the overview:

    Higher or Lower
    Path: Games/Higher_lower

    Gamble
    Path: Games/gambler

    Memorise cards
    Path: Games/memory_game

    Encoding and decoding images
    Path: Tools/Image encoding and decoding

Modified the README.md file to add the missing games and tools to the overview section of the file.