### PR TITLE
Fixed snake_game from crashing upon eating.

### DIFF
--- a/Games/snake_game/constants.py
+++ b/Games/snake_game/constants.py
@@ -26,5 +26,5 @@ OPPOSITE_DIRECTIONS = {'up': 'down', 'down': 'up', 'left': 'right', 'right': 'le
 TURTLE_SIZE = 20
 
 # Boundary limit, considering the size of the turtle
-BOUNDARY_LIMIT = SCREEN_WIDTH / 2
+BOUNDARY_LIMIT = SCREEN_WIDTH // 2
 


### PR DESCRIPTION
Eating a circle in snake_game would cause a crash. This was from BOUNDARY_LIMIT in constants.py using regular division which was fed into a random function. Even as a flat number that number was still a float from the initial division but in this context floor division will cause the BOUNDARY_LIMIT to always be an integer. 

<img width="967" height="254" alt="trim" src="https://github.com/user-attachments/assets/19084fd6-4c4d-458c-91ea-9cfcee117eec" />
